### PR TITLE
Expands lexer tests for astring with closer attention to ABNF in spec

### DIFF
--- a/lexer_test.go
+++ b/lexer_test.go
@@ -32,14 +32,95 @@ func TestLiteral(t *testing.T) {
 
 }
 
+// TestAstring checks the lexer will return a valid <astring> per the ABNF rule, or panic on a failing test
+//
+// Astring = 1*ASTRING-CHAR / string
+//     ASTRING-CHAR = ATOM-CHAR / resp-specials
+//         ATOM-CHAR = <any CHAR except atom-specials>
+//             atom-specials = "(" / ")" / "{" / SP / CTL / list-wildcards / quoted-specials / resp-specials
+//                 list-wildcards = "%" / "*"
+//                 quoted-specials = DQUOTE / "\"
+//                 resp-specials   = "]"
+//     string = quoted / literal
+//         quoted = DQUOTE *QUOTED-CHAR DQUOTE
+//             QUOTED-CHAR = <any TEXT-CHAR except quoted-specials> / "\" quoted-specials
+//                 TEXT-CHAR = <any CHAR except CR and LF>
+//                 quoted-specials = DQUOTE / "\"
+//         literal = "{" number "}" CRLF *CHAR8 ; number represents the number of CHAR8s
+//
+// SP  = %x20
+// CTL = %x00-1F / %x7F ; controls
+// DQUOTE = %x22
+// CR  = %x0D
+// LF  = %x0A
 func TestAstring(t *testing.T) {
 
-	r := bufio.NewReader(strings.NewReader("tHiS_IS#A_VAL!D_ASTRING \n"))
-	l := createLexer(r)
-	l.skipSpace()
-	tk := l.astring()
+	// Test cases receive a map of OUTPUT => INPUT
+	passing := map[string]string{
+		"a":    "a\r\n",     // 1*ASTRING-CHAR - single
+		"this": "this\r\n",  // 1*ASTRING-CHAR - many
+		"burb": "burb)\r\n", // 1*ASTRING-CHAR - stop at )
+		"\"\"": "\"\"\r\n",  // <quoted> with no *QUOTED-CHAR
+		"[":    "[\r\n",
+		//"{5} abcd": "{5}\r\n abcd\n", // TODO : Should pass under <string> alternative <literal>?
+		//"]":        "]\n",            // TODO : Should pass in <ASTRING-CHAR> under the <resp-specials> alternative
+	}
 
-	if tk.value != "tHiS_IS#A_VAL!D_ASTRING" {
+	// The failing test case map key is largely irrelevant as they should panic, just included for consistency
+	failing := map[string]string{
+		" ": " ", // SP
+		//"":   "",   // 1*ASTRING-CHAR should have at least one char // TODO : Gets EOF -- should panic?
+		"\\": "\\", // <quoted-specials> not allowed in ATOM-CHAR
+		//"\"": "\"", // DQUOTE // TODO : Gets EOF -- should panic?
+		"%": "%", // <list-wildcard>
+		"*": "*", // <list-wildcard>
+		")": ")", // <atom-specials> not allowed in ATOM-CHAR
+		"(": "(", // <atom-specials> not allowed in ATOM-CHAR
+	}
+
+	panicCount := 0
+
+	testAstring := func(in, out string) bool {
+
+		// Catch the panics and increment the panic counter for failures
+		defer func() {
+			if r := recover(); r != nil {
+				// EOFs are easily obscured as they are also a form of panic in the system
+				// but do not constitute an 'expected' panic type here
+				if r.(parseError).Error() == "EOF" {
+					t.Logf("Bad panic on input: %q, output: %q", in, out)
+					panic("EOF found in TestAstring - should not be present, correct the test(s)")
+				}
+				panicCount += 1
+			}
+		}()
+
+		r := bufio.NewReader(strings.NewReader(in))
+		l := createLexer(r)
+		l.skipSpace()
+		tk := l.astring()
+
+		return tk.value == out
+
+	}
+
+	for o, i := range passing {
+		if testAstring(i, o) != true {
+			t.Logf("Failed on passing case: input %q, output %q", i, o)
+			t.Fail()
+		}
+	}
+
+	for o, i := range failing {
+		if testAstring(i, o) != false {
+			// This should not be reached as all failing test cases should trigger a panic
+			t.Logf("Failed on failing case: input %q, output %q", i, o)
+			t.Fail()
+		}
+	}
+
+	if panicCount != len(failing) {
+		t.Logf("Expected %d panics, found %d", len(failing), panicCount)
 		t.Fail()
 	}
 


### PR DESCRIPTION
@alienscience As you're writing the lexer I've left this as a pull request for your review instead of just forcing it on you.

Some of the test cases do not pass, although I've left them commented out.  These need your eye as I'm not confident I can say they should or shouldn't pass - only that the RFC seems to allow them.

I've also reproduced the entire <astring> rule from the spec in the comment as a sort of tree - perhaps unnecessarily but just out of temporary convenience.  I'm conscious that this will come out as one long weird string under godocs in the long-term so I can happily remove it.

Still lacks a complete set of test cases (e.g. CTL is not tested)
