### PR TITLE
Fixed demo/auth with default dummyMailstore

### DIFF
--- a/demo/auth/main.go
+++ b/demo/auth/main.go
@@ -29,6 +29,7 @@ func main() {
 	s := imap.NewServer(
 		imap.ListenOption("127.0.0.1:1193"),
 		imap.AuthStoreOption(a),
+		imap.StoreOption(imap.NewDummyMailstore()),
 	)
 
 	// Firing up the server

--- a/mailstore.go
+++ b/mailstore.go
@@ -119,3 +119,8 @@ func (m *dummyMailstore) RecentMessages(mbox int64) (int64, error) {
 func (m *dummyMailstore) NextUid(mbox int64) (int64, error) {
 	return 9, nil
 }
+
+// Create new instance of DummyMailstore
+func NewDummyMailstore() Mailstore {
+	return &dummyMailstore{}
+}


### PR DESCRIPTION
On successful auth mailbox select was failing due to missing mailstore initialization.